### PR TITLE
update IANA OAuth Token Endpoint Authentication Methods

### DIFF
--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -639,6 +639,47 @@
         </section>
 
       </section>
+
+      <section title="OAuth Token Endpoint Authentication Methods" anchor="MethodsReg">
+        <t>
+          This section updates entries in the "OAuth Token Endpoint Authentication Methods" registry <xref target="IANA.OAuthParameters"/>
+        </t>
+
+        <section title="Registry Contents" anchor="MethodsContents">
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>
+                Token Endpoint Authentication Method Name: private_key_jwt
+              </t>
+              <t>
+                Change Controller: IESG
+              </t>
+              <t>
+                Reference: Section 9 of <xref target="OpenID.Core"/>, [[this specification]]
+              </t>
+            </list>
+            <?rfc subcompact="no"?>
+          </t>
+          <t></t>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>
+                Token Endpoint Authentication Method Name: client_secret_jwt
+              </t>
+              <t>
+                Change Controller: IESG
+              </t>
+              <t>
+                Reference: Section 9 of <xref target="OpenID.Core"/>, [[this specification]]
+              </t>
+            </list>
+            <?rfc subcompact="no"?>
+          </t>
+        </section>
+
+      </section>
     </section>
 
   </middle>
@@ -791,6 +832,16 @@
 	</front>
       </reference>
 
+      <reference anchor="IANA.OAuthParameters" target="https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml">
+	<front>
+	  <title>OAuth Parameters</title>
+	  <author>
+	    <organization>IANA</organization>
+	  </author>
+	  <date/>
+	</front>
+      </reference>
+
     </references>
 
     <section title="Document History" anchor="History">
@@ -799,6 +850,12 @@
       </t>
 
       <t>
+	-03
+	<list style="symbols">
+	  <t>
+	    Update OAuth Token Endpoint Authentication Methods IANA entries with reference to this specification
+	  </t>
+	</list>
 	-02
 	<list style="symbols">
 	  <t>


### PR DESCRIPTION
This adds an IANA Considerations subsection on updating the "OAuth Token Endpoint Authentication Methods" entries for private_key_jwt and client_secret_jwt to include the link to this specification in addition to its original definition.