### PR TITLE
client to ensure AAG audience makes sense

### DIFF
--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -210,8 +210,8 @@
 	    with an &lt;AudienceRestriction&gt; element
 	    with an &lt;Audience&gt; element that identifies the
 	    authorization server as the intended audience.
-	    It is the responsibility of the client to use only audience values
-	    that are specific to the authorization server being used.
+	    The client is responsible for ensuring that the audience of the Assertion
+	    is appropriate for the authorization server to which it is sent.
 	    This MAY be the issuer identifier of the authorization server,
 	    the token endpoint URL of the authorization server, or
 	    a SAML Entity ID.
@@ -224,67 +224,6 @@
 	  </t>
 	</list>
       </t>
-      <t>
-	In Section 4 of <xref target="RFC7522"/> (Authorization Grant Example),
-	the sentence:
-	<list style="empty">
-	  <t>
-	    The intended audience of the Assertion is
-	    <spanx style="verb">https://saml-sp.example.net</spanx>,
-	    which is an identifier for a SAML Service Provider
-	    with which the authorization server identifies itself.
-	  </t>
-	</list>
-	is replaced by:
-	<list style="empty">
-	  <t>
-	    The intended audience of the Assertion is
-	    <spanx style="verb">https://authz.example.net</spanx>,
-	    which is the authorization server's issuer identifier.
-	  </t>
-	</list>
-      </t>
-      <figure title="Example SAML 2.0 Assertion" anchor="assertion">
-	<preamble>
-	  In the same section, the SAML 2.0 Assertion example is replaced by:
-	</preamble>
-	<artwork><![CDATA[
-  <Assertion IssueInstant="2025-07-17T00:53:34.619Z"
-    ID="ef1xsbZxPV2oqjd7HTLRLIBlBb7"
-    Version="2.0"
-    xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
-   <Issuer>https://saml-idp.example.com</Issuer>
-   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-    [...omitted for brevity...]
-   </ds:Signature>
-   <Subject>
-    <NameID
-     Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">
-     brian@example.com
-    </NameID>
-    <SubjectConfirmation
-      Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-     <SubjectConfirmationData
-       NotOnOrAfter="2025-07-17T00:58:34.619Z"
-       Recipient="https://authz.example.net/token.oauth2"/>
-     </SubjectConfirmation>
-    </Subject>
-    <Conditions>
-      <AudienceRestriction>
-        <Audience>https://authz.example.net</Audience>
-      </AudienceRestriction>
-    </Conditions>
-    <AuthnStatement AuthnInstant="2025-07-17T00:53:34.371Z">
-      <AuthnContext>
-        <AuthnContextClassRef>
-          urn:oasis:names:tc:SAML:2.0:ac:classes:X509
-        </AuthnContextClassRef>
-      </AuthnContext>
-    </AuthnStatement>
-  </Assertion>
-]]></artwork>
-      </figure>
-
     </section>
 
     <section title="Updates to RFC 7523" anchor="RFC7523Updates">
@@ -869,7 +808,7 @@
 	    Do not restrict the "aud" claim's type. Allow it to be an array with a single member.
 	  </t>
 	  <t>
-		Advise the client to ensure that the audience of a JWT assertion authorization grant makes sense with respect to where it’s being sent.
+		Advise the client to ensure that the audience of an assertion authorization grant makes sense with respect to where it’s being sent.
 	  </t>
 	</list>
 	-02

--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -866,7 +866,10 @@
 	    Relaxed client requirement to use strong typed JWTs. SHOULD instead of MUST.
 	  </t>
 	  <t>
-	    Do not restrict the "aud" claim's type. Allow it to be a an array with a single member.
+	    Do not restrict the "aud" claim's type. Allow it to be an array with a single member.
+	  </t>
+	  <t>
+		Advise the client to ensure that the audience of a JWT assertion authorization grant makes sense with respect to where it’s being sent.
 	  </t>
 	</list>
 	-02

--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -154,28 +154,9 @@
 	  <t hangText="Audience">
 	    <vspace/>
             A value that identifies the party intended to process the assertion.
-	    The audience value MUST
-	    identify the authorization server as the intended audience.
-	    It is the responsibility of the client to use only audience values
-	    that are specific to the authorization server being used.
-	    This MAY be the issuer identifier of the authorization server.
-	    The authorization server MUST reject any assertion that does not
-	    contain its own identity as the intended audience.
-	  </t>
-	</list>
-      </t>
-      <t>
-	The description of the Audience parameter
-	in Section 5.2 of <xref target="RFC7521"/> (General Assertion Format and Processing Rules)
-	is replaced by:
-	<list style="empty">
-	  <t>
-	    The assertion MUST contain an audience value that identifies the
-	    authorization server as the intended audience.
-	    It is the responsibility of the client to use only audience values
-	    that are specific to the authorization server being used.
-	    The authorization server MUST reject any assertion that does not
-	    contain its own identity as the intended audience.
+           The issuer identifier of the authorization server,
+           as defined in <xref target="RFC8414"/>, can be used to indicate that
+           the authorization server is a valid intended audience of the assertion.
 	  </t>
 	</list>
       </t>

--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -177,7 +177,7 @@
 	<list style="empty">
 	  <t>
 	    It is RECOMMENDED that SAML Bearer Assertions
-	    not be used for for client authentication.
+	    not be used for client authentication.
 	  </t>
 	</list>
       </t>

--- a/draft-ietf-oauth-rfc7523bis.xml
+++ b/draft-ietf-oauth-rfc7523bis.xml
@@ -331,16 +331,10 @@
 	    <list style="letters">
 	      <t>
 		For the authorization grant,
-		it is the responsibility of the client to use only audience values
-		that are specific to the authorization server being used.
-		This MAY be either
-		the issuer identifier of the authorization server or
-		the token endpoint URL of the authorization server.
-		The authorization server MUST reject any JWT that does not
-		contain its own identity as the intended audience,
-		and if the value of <spanx style="verb">aud</spanx> is an array,
-		all array values MUST identify the authorization server
-		as the intended audience.
+		the client is responsible for ensuring that the audience of the JWT assertion
+		is appropriate for the authorization server to which it is sent. An
+		authorization server MAY be identified by either its issuer identifier
+		or its token endpoint URL.
 	      </t>
 	      <t>
 		For client authentication,


### PR DESCRIPTION
To fix #13

Advise the client to ensure that the audience of an assertion authorization grant (AAG) makes sense with respect to where it’s being sent.

See it rendered here https://drafts.oauth.net/draft-ietf-oauth-rfc7523bis/13-client-responsible/draft-ietf-oauth-rfc7523bis.html 